### PR TITLE
Exec/part1: Enhancements and Bug Fixes

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -25,6 +25,9 @@
 /** Invalid pointer error message for data cleanup */
 #define PTR_ERR ": clear_1data(): data pointer not found !"
 
+/** Critical error messages that will cause shell exit */
+#define FATAL_ERR "\033[1;31mFATAL:\033[0m "
+
 
 /**
  * @brief Clear operation modes
@@ -88,15 +91,17 @@ typedef enum e_token_type
  */
 typedef enum e_error_code
 {
-    DUP2_CODE = 2,   /**< Error code for dup2() system call failure */
-    CLOSE_CODE,      /**< Error code for close() system call failure */
-    PIPE_CODE,       /**< Error code for pipe() system call failure */
-    READ_CODE,       /**< Error code for read() system call failure */
-    OPEN_CODE,       /**< Error code for open() system call failure */
-    WRITE_CODE,      /**< Error code for write() system call failure */
-    FORK_CODE,       /**< Error code for fork() system call failure */
-    MALLOC_CODE,     /**< Error code for malloc() function failure */
-    READLINE_CODE    /**< Error code for readline() function failure */
+    DUP2_CODE = 2,       /**< Error code for dup2() system call failure */
+    CLOSE_CODE,          /**< Error code for close() system call failure */
+    PIPE_CODE,           /**< Error code for pipe() system call failure */
+    READ_CODE,           /**< Error code for read() system call failure */
+    OPEN_CODE,          /**< Error code for open() system call failure */
+    WRITE_CODE,          /**< Error code for write() system call failure */
+    FORK_CODE,          /**< Error code for fork() system call failure */
+    MALLOC_CODE,         /**< Error code for malloc() function failure */
+    READLINE_CODE,       /**< Error code for readline() function failure */
+    SIGTERM_CODE = 143,  /**< Termination signal error code */
+    SIGXCPU_CODE = 24    /**< CPU time limit exceeded signal error code */
 } t_error_code;
 
 

--- a/includes/macros.h
+++ b/includes/macros.h
@@ -149,6 +149,10 @@ typedef enum e_token_check_mode {
 // macro for empty variable
 # define EMPTY_VAR 0
 
+//mods for load_cmd
+# define COUNT 0
+# define LOAD 1
+
 // Regular text colors
 #define BLACK "\033[0;30m"
 #define RED "\033[0;31m"

--- a/includes/macros.h
+++ b/includes/macros.h
@@ -80,7 +80,8 @@ typedef enum e_token_type
     IN_RDRT = 2,         /* Input file redirection */
     OUT_RDRT_OW = 3,     /* Output file redirection (overwrite mode) */
     OUT_RDRT_APP = 4,    /* Output file redirection (append mode) */
-    WORD = 10            /* Regular word token */
+    WORD = 10,           /* Regular word token */
+    HERE_DOC_FD = 11
 } t_token_type;
 
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -141,6 +141,17 @@ int     exec_builtin(t_cmd * cmd);
 void    execution(void);
 
 
+/**
+ * @brief Fork helper that executes different functions in parent and child
+ * @param child_fn Function pointer for child process
+ * @param child_arg Argument for child function 
+ * @param parent_fn Function pointer for parent process
+ * @param parent_arg Argument for parent function
+ * @return Process ID in parent, -1 on error, child never returns
+ */
+pid_t   forker(void (*child_fn)(void *), void *child_arg,
+                    void (*parent_fn)(void *), void *parent_arg);
+
 
 
 /*          >Redirection Functions<           */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -138,11 +138,53 @@ void        load_cmd_list(t_all *core);
  */
 int     is_builtin(char *cmd);
 int     exec_builtin(t_cmd * cmd);
-int     ifd(char *filename);
-int     ofd(char *filename, char mode);
-void    hd_fork(char *tmpfile, char *delimit);
-int     hd(char *delimit);
 void    execution(void);
+
+
+
+
+/*          >Redirection Functions<           */
+/**
+ * @brief Opens a file for input redirection
+ * @details Opens the specified file in read-only mode
+ * @param filename Name of the file to open
+ * @return File descriptor of the opened file, or -1 on error
+ */
+int     ifd(char *filename);
+
+/**
+ * @brief Opens a file for output redirection
+ * @details Opens the specified file in write or append mode based on the mode parameter
+ * @param filename Name of the file to open
+ * @param mode Mode to open the file in (overwrite or append)
+ * @return File descriptor of the opened file, or -1 on error
+ */
+int     ofd(char *filename, char mode);
+
+/**
+ * @brief Forks a process to handle here-document input
+ * @details Creates a child process to read input until the delimiter is encountered
+ * @param tmpfile Name of the temporary file to store the here-document input
+ * @param delimit Delimiter string to end the here-document input
+ */
+void    hd_fork(char *tmpfile, char *delimit);
+
+/**
+ * @brief Handles here-document input
+ * @details Reads input from the user until the delimiter is encountered and stores it in a temporary file
+ * @param delimit Delimiter string to end the here-document input
+ * @return File descriptor of the temporary file containing the here-document input
+ */
+int     hd(char *delimit);
+
+/**
+ * @brief Duplicates file descriptors for input and output redirection
+ * @details Uses dup2 to duplicate the file descriptors for standard input and output
+ * @param ifd Input file descriptor to duplicate
+ * @param ofd Output file descriptor to duplicate
+ * @return true on success, false on error
+ */
+bool    duping(int ifd, int ofd);
 
 
 /*          >bultin functions<           */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -142,6 +142,7 @@ int     ifd(char *filename);
 int     ofd(char *filename, char mode);
 void    hd_fork(char *tmpfile, char *delimit);
 int     hd(char *delimit);
+void    execution(void);
 
 
 /*          >bultin functions<           */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -197,6 +197,8 @@ int     hd(char *delimit);
  */
 bool    duping(int ifd, int ofd);
 
+bool    prepare_ifof(t_cmd *cmd_list);
+
 
 /*          >bultin functions<           */
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -133,6 +133,8 @@ void        expanding(t_lx *lexer);
  * @param core Main shell structure containing lexer tokens
  */
 void        load_cmd_list(t_all *core);
+
+void        load_cmd(t_cmd *cmd_list);
 /*          >Execution Functions<           */
 /**
  */

--- a/source/execution/builtin/builtin.c
+++ b/source/execution/builtin/builtin.c
@@ -25,17 +25,17 @@ int is_builtin(char *cmd)
 int exec_builtin(t_cmd * cmd)
 {
 	if (ft_strcmp(cmd->cmd[0], "cd") == 0)
-		ft_cd(cmd);
+		return (ft_cd(cmd));
 	if (ft_strcmp(cmd->cmd[0], "echo") == 0)
-		ft_echo(cmd);		
+		return (ft_echo(cmd));		
 	if (ft_strcmp(cmd->cmd[0], "pwd") == 0)
-		ft_pwd();
+		return (ft_pwd());
 	if (ft_strcmp(cmd->cmd[0], "env") == 0)
-		ft_env();
+		return (ft_env());
 	if (ft_strcmp(cmd->cmd[0], "export") == 0)
-		ft_export(cmd);
+		return (ft_export(cmd));
 	if (ft_strcmp(cmd->cmd[0], "unset") == 0)
-		ft_unset(cmd);
-    return (0);
+		return (ft_unset(cmd));
+    return (2011);
 }
 

--- a/source/execution/builtin/ft_cd.c
+++ b/source/execution/builtin/ft_cd.c
@@ -33,7 +33,7 @@ static int cha_dir(char *dir)
             return (pexit(ft_strjoin("cd: ",dir), 1), 1); 
     }
     update_env_cwd(oldpwd);
-    return (1);
+    return (0);
 }
 
 int ft_cd(t_cmd *cmd)

--- a/source/execution/builtin/ft_env.c
+++ b/source/execution/builtin/ft_env.c
@@ -24,11 +24,11 @@ int    ft_env()
 
     env = getcore()->env_list;
     if (env == NULL)
-        return (0);
+        return (1);
     while (env)
     {
         printf("%s=%s\n", env->key, env->value);
         env = env->next;
     }
-    return (1);
+    return (0);
 }

--- a/source/execution/builtin/ft_export.c
+++ b/source/execution/builtin/ft_export.c
@@ -76,20 +76,25 @@ int    ft_export(t_cmd *cmd)
 {
     size_t i;
     bool has_plus;
+    bool failed;
 
     i = 1;
     has_plus = 0;
+    failed = 0;
     while (cmd->cmd[i])
     {
         if (ft_export_check(cmd->cmd[i], &has_plus))
             ft_add_export(cmd->cmd[i], has_plus);
         else
+        {
             ft_print_export_error(cmd->cmd[i]);
+            failed = 1;
+        }
         i++;
         has_plus = 0;
     }
     if (!cmd->cmd[1])
         ft_print_export();
-    return (0);
+    return (failed);
 }
 

--- a/source/execution/builtin/ft_unset.c
+++ b/source/execution/builtin/ft_unset.c
@@ -95,5 +95,5 @@ int     ft_unset(t_cmd *cmd)
             return (ft_remove_node(cmd->cmd[1]), 0);
         env = env->next;
     }
-    return (1);
+    return (0);
 }

--- a/source/execution/execution.c
+++ b/source/execution/execution.c
@@ -116,25 +116,25 @@ static int ft_print_export_error2(char *cmd)
     return (0);
 } 
 
-int    ft_export2(t_cmd *cmd)
-{
-    size_t i;
-    int exit_status;
+// int    ft_export2(t_cmd *cmd)
+// {
+//     size_t i;
+//     int exit_status;
 
-    i = 1;
-    exit_status = 0;
-    while (cmd->cmd[i])
-    {
-        if (ft_export_check3(cmd->cmd[i]))
-            ft_add_export3(cmd->cmd[i]);
-        else
-            exit_status = ft_print_export_error2(cmd->cmd[i]);
-        i++;
-    }
-    if (!cmd->cmd[1])
-        ft_print_export2();
-    return (0);
-}
+//     i = 1;
+//     exit_status = 0;
+//     while (cmd->cmd[i])
+//     {
+//         if (ft_export_check3(cmd->cmd[i]))
+//             ft_add_export3(cmd->cmd[i]);
+//         else
+//             exit_status = ft_print_export_error2(cmd->cmd[i]);
+//         i++;
+//     }
+//     if (!cmd->cmd[1])
+//         ft_print_export2();
+//     return (0);
+// }
 
 
 //TO DOs : 1 ->fix export [x]
@@ -225,7 +225,7 @@ void run_tests() {
     }
 }
 
-int main() {
-    run_tests();
-    return 0;
-}
+// int main() {
+//     run_tests();
+//     return 0;
+// }

--- a/source/execution/execution.c
+++ b/source/execution/execution.c
@@ -48,8 +48,8 @@ void test_export(void)
     clear(FREE_ALL);
 }
 
-int main(void)
-{
-    test_export();
-    return 0;
-}
+// int main(void)
+// {
+//     test_export();
+//     return 0;
+// }

--- a/source/execution/execution_real.c
+++ b/source/execution/execution_real.c
@@ -1,10 +1,5 @@
 #include "minishell.h"
 
-
-
-
-
-
 unsigned int count_or_back(t_cmd *cmd, bool type)
 {
     unsigned int i;
@@ -44,4 +39,5 @@ void    execution(void)
 {
     load_cmd(getcore()->cmd);
     print_cmd();
+    
 }

--- a/source/execution/execution_real.c
+++ b/source/execution/execution_real.c
@@ -1,0 +1,47 @@
+#include "minishell.h"
+
+
+
+
+
+
+unsigned int count_or_back(t_cmd *cmd, bool type)
+{
+    unsigned int i;
+    t_lx *lx;
+
+    lx = cmd->scope;
+    i = 0;
+    while (lx)
+    {
+        if (lx->type == WORD && (!lx->prev || (lx->prev && !istoken(lx->prev->type, NON_PIPE))))
+        {
+            if (type == COUNT)
+                i++;
+            else
+                cmd->cmd[i++] = lx->content;
+        }
+        lx = lx->next;
+    }
+    return (i);
+}
+
+void load_cmd(t_cmd *cmd_list)
+{
+    unsigned int size;
+
+    while (cmd_list)
+    {
+        size = count_or_back(cmd_list, COUNT);
+        cmd_list->cmd = galloc(sizeof(char *) * (size + 1));
+        count_or_back(cmd_list, LOAD);
+        cmd_list->cmd[size] = NULL;
+        cmd_list = cmd_list->next;
+    }
+}
+
+void    execution(void)
+{
+    load_cmd(getcore()->cmd);
+    print_cmd();
+}

--- a/source/execution/execution_real.c
+++ b/source/execution/execution_real.c
@@ -1,5 +1,14 @@
 #include "minishell.h"
 
+void exec_1cmd(t_cmd *cmd)
+{
+    if (is_builtin(cmd->cmd[0]))
+    {
+        
+    }
+    
+}
+
 unsigned int count_or_back(t_cmd *cmd, bool type)
 {
     unsigned int i;
@@ -35,9 +44,13 @@ void load_cmd(t_cmd *cmd_list)
     }
 }
 
+// exitcode formula (exit_code % 256 + 256) % 256
 void    execution(void)
 {
     load_cmd(getcore()->cmd);
     print_cmd();
-    
+    if (getcore()->cmd_count == 1)
+        exec_1cmd(getcore()->cmd);
+    else
+        exec_ncmd(getcore()->cmd);
 }

--- a/source/execution/execution_real.c
+++ b/source/execution/execution_real.c
@@ -1,13 +1,37 @@
 #include "minishell.h"
 
-void exec_1cmd(t_cmd *cmd)
+int exec_1cmd(t_cmd *cmd)
 {
+    int backup_fd[2];
     if (is_builtin(cmd->cmd[0]))
     {
-        
+        backup_fd[0] = dup(STDIN_FILENO);
+        backup_fd[1] = dup(STDOUT_FILENO);
+        prepare_ifof(getcore()->cmd);
+        // to change to void
+        exec_builtin(cmd->cmd);
+        if (dup2(backup_fd[0], cmd->ifd) < 0 || dup2(backup_fd[1], cmd->ofd))
+            return(pexit("dup2", DUP2_CODE), 1);
     }
-    
+    else
+    {
+        if (execvp(cmd->cmd[0], cmd->cmd) == -1)
+        {
+            //command not found 
+            pexit(cmd->cmd[0], 127);
+            return (1);
+        }
+        return (0);
+    }
+    return (1);
 }
+
+int  exec_ncmd(t_cmd *cmd)
+{
+
+
+    return (0);
+}   
 
 unsigned int count_or_back(t_cmd *cmd, bool type)
 {
@@ -36,6 +60,7 @@ void load_cmd(t_cmd *cmd_list)
 
     while (cmd_list)
     {
+        cmd_list->ofd = 1;
         size = count_or_back(cmd_list, COUNT);
         cmd_list->cmd = galloc(sizeof(char *) * (size + 1));
         count_or_back(cmd_list, LOAD);
@@ -44,13 +69,13 @@ void load_cmd(t_cmd *cmd_list)
     }
 }
 
-// exitcode formula (exit_code % 256 + 256) % 256
+// exitcode formula (exit_code % 256 + 256) % 256 == exit_code & 0xFF
 void    execution(void)
 {
-    load_cmd(getcore()->cmd);
+    prepare_ifof(getcore()->cmd);
     print_cmd();
-    if (getcore()->cmd_count == 1)
-        exec_1cmd(getcore()->cmd);
-    else
-        exec_ncmd(getcore()->cmd);
+    // if (getcore()->cmd_count == 1)
+    //     exec_1cmd(getcore()->cmd);
+    // else
+    //     exec_ncmd(getcore()->cmd);
 }

--- a/source/execution/execution_real1.c
+++ b/source/execution/execution_real1.c
@@ -1,0 +1,20 @@
+#include "minishell.h"
+
+pid_t   forker(void (*child_fn)(void *), void *child_arg,
+                    void (*parent_fn)(void *), void *parent_arg)
+{
+    pid_t   pid;
+
+    if (!child_fn || !parent_fn)
+        return(pexit(":forker: "FATAL_ERR"function pointer is NULL !", 1), -1);
+    pid = fork();
+    if (pid == -1)
+    {
+        pexit("fork", FORK_CODE);
+        return (-1);
+    }
+    if (pid == 0)
+        (child_fn(child_arg), exit(211));
+    parent_fn(parent_arg);
+    return (pid);
+}

--- a/source/execution/redirections/hd.c
+++ b/source/execution/redirections/hd.c
@@ -63,7 +63,7 @@ static char    *tmphd(char **env)
     pid_t pid;
     int pip[2];
 
-    if (pipe(pip))
+    if (pipe(pip) < 0)
         pexit("pipe", PIPE_CODE);
     pid = fork();
     if (pid < 0)

--- a/source/execution/redirections/ifd.c
+++ b/source/execution/redirections/ifd.c
@@ -1,5 +1,22 @@
 #include "minishell.h"
 
+bool    duping(int ifd, int ofd)
+{
+    if (ifd > 2)
+    {
+        if (dup2(ifd, STDIN_FILENO) < 0)
+            return (pexit("dup2", DUP2_CODE), false);
+        close(ifd);
+    }
+    if (ofd > 2)
+    {
+        if (dup2(ofd, STDOUT_FILENO) < 0)
+            return (pexit("dup2", DUP2_CODE), false);
+        close(ofd);
+    }
+    return(true);
+}
+
 int     ifd(char *filename)
 {
     int fd;

--- a/source/execution/redirections/ifd.c
+++ b/source/execution/redirections/ifd.c
@@ -23,6 +23,6 @@ int     ifd(char *filename)
 
     fd = open(filename, O_RDONLY, 0666);
     if (fd < 0)
-        pexit(ft_strjoin("open: ", filename), OPEN_CODE);
+        pexit(filename, OPEN_CODE);
     return (fd);
 }

--- a/source/execution/redirections/redirection.c
+++ b/source/execution/redirections/redirection.c
@@ -2,14 +2,42 @@
 
 int     redirection(char *filename, char mode, int oldfd)
 {
+    if (oldfd > 2)
+        close (oldfd);
     if (mode == HERE_DOC)
         return (hd(filename));
+    if (mode == HERE_DOC_FD)
+        return (ft_atoi(filename));
     else if (mode == IN_RDRT)
         return (ifd(filename));
     else
         return (ofd(filename, mode));
-    if (oldfd > 2)
-        close (oldfd);
+}
+
+static bool prepere_heredoc(t_cmd *cmd_list)
+{
+    int fd;
+    t_lx *lexer;
+
+    while (cmd_list)
+    {
+        lexer = cmd_list->scope;
+        while (lexer)
+        {
+            if (lexer->type == HERE_DOC)
+            {
+                fd = redirection(lexer->next->content, lexer->type, 0);
+                if (fd < 0)
+                    return (false);
+                clear_1data(lexer->next->content);
+                lexer->type = HERE_DOC_FD;
+                lexer->next->content = ft_itoa(fd);
+            }
+            lexer = lexer->next;
+        }
+        cmd_list = cmd_list->next;
+    }
+    return (true);
 }
 
 bool    prepare_ifof(t_cmd *cmd_list)
@@ -17,12 +45,27 @@ bool    prepare_ifof(t_cmd *cmd_list)
     t_lx *lexer;
 
     lexer = cmd_list->scope;
+    if (!prepere_heredoc(cmd_list))
+        return (false);
     while (lexer)
-    {
-        if (lexer->type == IN_RDRT || lexer->type == HERE_DOC)
+    {   
+        if (lexer->type == IN_RDRT || lexer->type == HERE_DOC_FD)
             cmd_list->ifd = redirection(lexer->next->content, lexer->type, cmd_list->ifd);
         else if (lexer->type == OUT_RDRT_APP || lexer->type == OUT_RDRT_OW)
             cmd_list->ofd = redirection(lexer->next->content, lexer->type, cmd_list->ofd);
+        if (cmd_list->ofd < 0 || cmd_list->ifd < 0)
+            return (false);
         lexer = lexer->next;
     }
+    if (cmd_list->ifd > 2)
+    {
+        if (dup2(cmd_list->ifd, STDIN_FILENO) < 0)
+            pexit("dup2", DUP2_CODE);
+    }
+    if (cmd_list->ofd > 2)
+    {
+        if (dup2(cmd_list->ofd, STDOUT_FILENO) < 0)
+            pexit("dup2", DUP2_CODE);
+    }
+    return(true);
 }

--- a/source/execution/redirections/redirection.c
+++ b/source/execution/redirections/redirection.c
@@ -11,3 +11,8 @@ int     redirection(char *filename, char mode, int oldfd)
     if (oldfd > 2)
         close (oldfd);
 }
+
+bool    prepare_ifof(void)
+{
+    
+}

--- a/source/execution/redirections/redirection.c
+++ b/source/execution/redirections/redirection.c
@@ -12,7 +12,17 @@ int     redirection(char *filename, char mode, int oldfd)
         close (oldfd);
 }
 
-bool    prepare_ifof(void)
+bool    prepare_ifof(t_cmd *cmd_list)
 {
-    
+    t_lx *lexer;
+
+    lexer = cmd_list->scope;
+    while (lexer)
+    {
+        if (lexer->type == IN_RDRT || lexer->type == HERE_DOC)
+            cmd_list->ifd = redirection(lexer->next->content, lexer->type, cmd_list->ifd);
+        else if (lexer->type == OUT_RDRT_APP || lexer->type == OUT_RDRT_OW)
+            cmd_list->ofd = redirection(lexer->next->content, lexer->type, cmd_list->ofd);
+        lexer = lexer->next;
+    }
 }

--- a/source/minishell.c
+++ b/source/minishell.c
@@ -7,8 +7,10 @@ int main(int ac, char *av[], char *env[])
 	fill_env_list(env);
 	while (true)
 	{
-		reader_loop();
-		parsing();
 		clear(FREE_TEMP);
+		reader_loop();
+		if (!parsing())
+			continue;
+		execution();
 	}
 }

--- a/source/parser/Utils/utils.c
+++ b/source/parser/Utils/utils.c
@@ -180,8 +180,21 @@ void print_cmd(void)
         printf(BOLD_GREEN "  Input  FD: " END "%d\n", cmd->ifd);
         printf(BOLD_GREEN "  Output FD: " END "%d\n", cmd->ofd);
 
-        t_lx *scope = cmd->scope;
+        // Print command array
+        printf(BOLD_MAGENTA "  Command Array:" END "\n");
+        if (cmd->cmd) {
+            int j = 0;
+            while (cmd->cmd[j]) {
+                printf(BOLD_CYAN "    [%d]: " END BOLD_WHITE "%s\n" END, j, cmd->cmd[j]);
+                j++;
+            }
+        } else {
+            printf(BOLD_RED "    No command array\n" END);
+        }
+
+        // Print scope
         printf(BOLD_MAGENTA "  Scope:" END "\n");
+        t_lx *scope = cmd->scope;
         while (scope) {
             printf(BOLD_BLUE "    Content: " END "%s\n", scope->content);
             scope = scope->next;

--- a/source/parser/cmd.c
+++ b/source/parser/cmd.c
@@ -96,4 +96,5 @@ void    load_cmd_list(t_all *core)
         }
         lexer = lexer->next;
     }
+    load_cmd(core->cmd);
 }

--- a/source/parser/parsing.c
+++ b/source/parser/parsing.c
@@ -49,7 +49,5 @@ bool    parsing(void)
     printf(BOLD_CYAN "\n╔═══════════════════ COMMAND LIST ═══════════════════╗\n");
     printf("║         Displaying parsed command structure         ║\n");
     printf("╚════════════════════════════════════════════════════╝\n" END);
-    
-    print_cmd();
     return (true);
 }

--- a/source/parser/parsing.c
+++ b/source/parser/parsing.c
@@ -10,12 +10,14 @@ void    reader_loop(void)
     {
         prompt = create_prompt();
         line = readline(prompt);
-        gc_add_node(line);
-        if (!line)
-            return (pexit(": done!", 0), clear(FREE_ALL), exit(0));
-        if (line[0] == 0 || ft_isspace(0, line))
+        if (line == NULL || line[0] == 0 || ft_isspace(0, line))
+        {
+            if (line)
+                free(line);
             continue;
+        }
         getcore()->in_line = line;
+        gc_add_node(line);
         // previous_line = getcore()->previous_line;
         add_history(line);
         break ;
@@ -32,20 +34,19 @@ bool    parsing(void)
     core->inline_len = ft_strlen(core->in_line);
     if (!check_quotes(core->in_line) || !lexing(core->in_line))
         return (false);
-    print_lx();
     if (needexpand(core->in_line))
         expanding(core->lexer);
     final_touch(core->lexer); // remove all kind of quotes in begging or in middle 
     
-    printf(BOLD_MAGENTA "╔══════════════════════════════════════════════════════╗\n");
-    printf("║              PARSER: AFTER FINAL TOUCH               ║\n");
-    printf("╚══════════════════════════════════════════════════════╝\n" END);
-    print_lx();
+    // printf(BOLD_MAGENTA "╔══════════════════════════════════════════════════════╗\n");
+    // printf("║              PARSER: AFTER FINAL TOUCH               ║\n");
+    // printf("╚══════════════════════════════════════════════════════╝\n" END);
+    // print_lx();
     
     load_cmd_list(core);
 
-    printf(BOLD_CYAN "\n╔═══════════════════ COMMAND LIST ═══════════════════╗\n");
-    printf("║         Displaying parsed command structure         ║\n");
-    printf("╚════════════════════════════════════════════════════╝\n" END);
+    // printf(BOLD_CYAN "\n╔═══════════════════ COMMAND LIST ═══════════════════╗\n");
+    // printf("║         Displaying parsed command structure         ║\n");
+    // printf("╚════════════════════════════════════════════════════╝\n" END);
     return (true);
 }

--- a/source/parser/parsing.c
+++ b/source/parser/parsing.c
@@ -10,14 +10,12 @@ void    reader_loop(void)
     {
         prompt = create_prompt();
         line = readline(prompt);
-        if (line == NULL || line[0] == 0 || ft_isspace(0, line))
-        {
-            if (line)
-                free(line);
-            continue;
-        }
-        getcore()->in_line = line;
         gc_add_node(line);
+        if (!line)
+            return (pexit(": done!", 0), clear(FREE_ALL), exit(0));
+        if (line[0] == 0 || ft_isspace(0, line))
+            continue;
+        getcore()->in_line = line;
         // previous_line = getcore()->previous_line;
         add_history(line);
         break ;


### PR DESCRIPTION
This pull request includes several significant changes to the `Makefile`, header files, and source files to enhance the functionality and robustness of the minishell project. The changes introduce memory testing commands, new error codes, additional functions, and improvements to existing functions. Here are the most important changes:

### Makefile Enhancements:
* Added commands for memory testing using Valgrind and ASAN, including the detection of the operating system to set the appropriate command.
* Introduced a `check_supp` function to create or update the suppression file for Valgrind and added `memtest`, `memtest-linux`, and `memtest-mac` targets.

### Header File Updates:
* Defined new error messages and codes, including `FATAL_ERR`, `SIGTERM_CODE`, and `SIGXCPU_CODE`. [[1]](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1R28-R30) [[2]](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1L99-R105)
* Added new token types and macros for command loading. [[1]](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1L80-R84) [[2]](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1R158-R161)
* Declared new functions for command execution and redirection handling, such as `execution`, `forker`, `duping`, and others.

### Source File Modifications:
* Updated the `exec_builtin` function to return the result of the executed built-in command.
* Improved the `ft_cd`, `ft_env`, `ft_export`, and `ft_unset` functions to return appropriate status codes. [[1]](diffhunk://#diff-e2eb9bb592d7d76923c6f008e32db8ad32417628113716804369446e76bb6a32L36-R36) [[2]](diffhunk://#diff-c493150167370d8246d46b38a9e7fb7a773f7802e161d294e0447ec15d008efaL27-R33) [[3]](diffhunk://#diff-d247ae7d318175adb3d8e28b9575b5635aea502be3e9a0e4697c2709be552f62R79-R98) [[4]](diffhunk://#diff-2e4188e4fc27071c202198f6ae6081d24fd1d911d893763c5b8877af54db3060L98-R98)
* Added new functions for command execution (`exec_1cmd`, `exec_ncmd`, `execution`) and redirection handling (`duping`, `prepare_ifof`). [[1]](diffhunk://#diff-731d2a487502749fcc80e1c63fc809a3455a496c12d10f5bb390d6102ce705a6R1-R81) [[2]](diffhunk://#diff-3126cfc1d5e498a074ab376184da20eefe89a629e6812c137ed938b732091064R3-R26) [[3]](diffhunk://#diff-39293d4b87bd25f6559e0f71bb3311ca4d00296066a5ef07e2ac99cd527e5db9R5-R70)
* Modified the main loop to include the `execution` function after parsing.

These changes collectively enhance the shell's functionality, error handling, and debugging capabilities.