### PR TITLE
Fix/shell bugs

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -74,12 +74,13 @@ typedef enum e_quote_type {
  */
 typedef enum e_token_type
 {
-    PIPE = -1,           /* Pipe operator token */
     TOKEN = -2,          /* Generic token identifier */
+    PIPE = -1,           /* Pipe operator token */
     HERE_DOC = 1,        /* Here document redirection */
     IN_RDRT = 2,         /* Input file redirection */
     OUT_RDRT_OW = 3,     /* Output file redirection (overwrite mode) */
     OUT_RDRT_APP = 4,    /* Output file redirection (append mode) */
+    AMBIG_RDRT = 5,      /* Ambiguous redirection error */
     WORD = 10,           /* Regular word token */
     HERE_DOC_FD = 11
 } t_token_type;
@@ -101,6 +102,7 @@ typedef enum e_error_code
     FORK_CODE,          /**< Error code for fork() system call failure */
     MALLOC_CODE,         /**< Error code for malloc() function failure */
     READLINE_CODE,       /**< Error code for readline() function failure */
+    AMBIG_CODE = 20,     /**< Error code for ambiguous redirection */
     PERM_DENIED_CODE = 126,   /**< Permission denied (not executable) */
     CMD_NOT_FOUND_CODE = 127, /**< Command not found in PATH */
     SIGTERM_CODE = 143,  /**< Termination signal error code */
@@ -172,6 +174,9 @@ typedef enum e_token_check_mode {
 
 //macro pexit func to exit ot not
 # define EXIT 1
+
+//macro for ambigous redirection
+# define AMBIG_ERR ": ambiguous redirect !"
 
 // Regular text colors
 #define BLACK "\033[0;30m"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -12,6 +12,7 @@ typedef struct s_lx
 {
     char   type;
     char            *content;
+    char            *original_content;
     struct s_lx     *next;
     struct s_lx     *prev;
 }   t_lx;
@@ -66,6 +67,8 @@ typedef struct s_all
     char            *previous_line;
     pid_t           *pids;
     bool            error_flag;
+    bool            sig_init;
+    bool            sig_quit;
 }       t_all;
 
 typedef struct s_ndx
@@ -198,6 +201,7 @@ bool    duping(int ifd, int ofd);
 
 bool    prepare_ifof(t_cmd *cmd_list);
 bool    backup_fd(int *fd);
+bool    prepare_heredoc(t_cmd *cmd_list);
 void    exec_cmdchild(void *data);
 void    exec_cmdparent(void *data, pid_t pid);
 
@@ -238,7 +242,7 @@ bool        ft_isspace(int c, char *str);
 bool        istoken(int c, bool type);
 char        *strtkr_gen(char type);
 void        reader_loop(void);
-bool        needexpand(char *str);
+bool        needexpand(char *str, t_lx *lexer);
 int         get_dollar(char *str, bool *flag);
 t_var       *handle_list(void);
 char        *get_end_addr(char *str);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -250,7 +250,7 @@ bool        possible_expand(char c);
 void        strocpy(char *dest, const char * src, int len);
 bool        is_str_havespace(char *string);
 void        addtolist(void *node, char *list_type, void *head);
-char        *strchrdup(char *str, char *delimit, bool type);
+char        *strchrdup(const char *str, char *delimit, bool type);
 void        *getlastnode(void *list, char *list_type);
 t_lx        *splitcontent(char *str);
 void        ft_update_path(void);

--- a/source/clear/clear.c
+++ b/source/clear/clear.c
@@ -5,17 +5,20 @@ static void re_zero(void)
     t_all *core;
     void *data;
     void **data1;
+    void **data2;
     unsigned char value;
 
     core = getcore();
     //keep env_list and exit code because its needed while program run time
+    value = core->exit_code;
     data = (void *)core->env_list;
     data1 = (void **)core->path;
-    value = core->exit_code;
+    data2 = (void **)core->env;
     ft_bzero(getcore(), sizeof(t_all)); // init all struct with 0;
+    core->exit_code = value;
     core->env_list = (t_env *)data;
     core->path = (char **)data1;
-    core->exit_code = value;
+    core->env = (char **)data2;
 }
 
 void safe_free(void **data)

--- a/source/execution/builtin/builtin.c
+++ b/source/execution/builtin/builtin.c
@@ -24,6 +24,8 @@ int is_builtin(char *cmd)
 
 int exec_builtin(t_cmd * cmd)
 {
+	if (!cmd->cmd)
+		return (0);
 	if (ft_strcmp(cmd->cmd[0], "cd") == 0)
 		return (ft_cd(cmd));
 	if (ft_strcmp(cmd->cmd[0], "echo") == 0)

--- a/source/execution/builtin/ft_export.c
+++ b/source/execution/builtin/ft_export.c
@@ -31,7 +31,8 @@ static int ft_export_check(char *arg, bool *has_plus)
     return (1);
 }
 
-static int parse_key_value(const char *arg, char **key, char **value) {
+static void parse_key_value(const char *arg, char **key, char **value) 
+{
     char *equal_sign_pos;
     
     equal_sign_pos = ft_strchr(arg, '=');
@@ -39,17 +40,13 @@ static int parse_key_value(const char *arg, char **key, char **value) {
     {
         *key = ft_strdup(arg);
         *value = NULL;
-        return (*key) ? 1 : 0;
+        return ;
     }
     if (*(equal_sign_pos - 1) == '+')
-        *key = ft_strndup(arg, equal_sign_pos - arg - 1);
+        *key = strchrdup(arg, equal_sign_pos - 1, CALLOC);
     else
-        *key = ft_strndup(arg , equal_sign_pos - arg);
-    if (*(equal_sign_pos + 1) == '\0')
-        *value = ft_strdup("");
-    else if (equal_sign_pos)
-        *value = ft_strdup(equal_sign_pos + 1);
-    return (*key && *value) ? 1 : 0;
+        *key = strchrdup(arg, equal_sign_pos , CALLOC);
+    *value = strchrdup(equal_sign_pos + 1, NULL , CALLOC);
 }
 
 static int ft_add_export(char *arg, bool has_plus)

--- a/source/execution/builtin/ft_unset.c
+++ b/source/execution/builtin/ft_unset.c
@@ -1,5 +1,3 @@
-
-
 #include "minishell.h"
 
 int     ft_add_node(t_env *last_node, char *new_key, char *new_val)
@@ -8,16 +6,12 @@ int     ft_add_node(t_env *last_node, char *new_key, char *new_val)
 
     if (!last_node)
         return (0);
-    env = galloc(sizeof(t_env));
+    env = ft_calloc(1, sizeof(t_env));
     if (!env)
         return (0);
     env->key = new_key;
     env->value = new_val;
-    env->next = NULL;
-    if (last_node && last_node->next == NULL)
-        last_node->next = env;
-    else
-        return (0);
+    addtolist(env, "t_env", NULL);
     return (1);
 }
 
@@ -36,8 +30,7 @@ void    ft_remove_node(char *node)
                 getcore()->env_list = env->next;
             else
                 prev->next = env->next;
-            free(env->key);
-            free(env->value);
+            (free(env->key), free(env->value));
             free(env);
             break;
         }
@@ -45,6 +38,25 @@ void    ft_remove_node(char *node)
         env = env->next;
     }
 }
+
+static void update_env_value(t_env *env, char *val, int overwrite)
+{
+    char *tmp;
+
+    if ((overwrite == 2) && val)
+    {
+        tmp = env->value;
+        env->value = ft_strjoin_m(env->value, val);
+        free(tmp);
+        free(val);
+    }
+    else if (overwrite == 1 && val)
+    {
+        free(env->value);
+        env->value = val;
+    }
+}
+
 /**  @brief same as the orignal setenv(3), 
 *    except tar9i3a of overwrite == 2 
 *    for appending env variable with += 
@@ -58,31 +70,28 @@ void    ft_remove_node(char *node)
 int     ft_setenv(char *key, char *val, int overwrite)
 {
     t_env *env;
-    t_env *prev;
     bool found;
 
     env = getcore()->env_list;
-    prev = NULL;
     found = false;
     while (env)
     {
         if (ft_strcmp(key, env->key) == 0)
         {
-            if ((overwrite == 2) && val)
-                env->value = ft_strjoin(env->value, val);
-            else if (overwrite && val)
-                env->value = val;
+            update_env_value(env, val, overwrite);
             found = true;
             break;
         }
-        prev = env;
         env = env->next;
     }
     if (!found)
-        if (ft_add_node(prev, key, val) == 0)
-            return -1;
-    return 1;
+    {
+        if (ft_add_node(getlastnode(getcore()->env_list, "t_env"), key, val) == 0)
+            return (1);
+    }
+    return (0);
 }
+
 
 int     ft_unset(t_cmd *cmd)
 {

--- a/source/execution/execution.c
+++ b/source/execution/execution.c
@@ -14,7 +14,7 @@ void exec_1cmd(t_cmd *cmd)
         backup_fd(bfd);
     }
     else
-        forker(exec_cmdchild, cmd, exec_cmdparent, &bfd[2]);
+        forker(exec_cmdchild, cmd, exec_cmdparent, NULL);
 }
 
 void  exec_ncmd(t_cmd *cmd)

--- a/source/execution/execution1.c
+++ b/source/execution/execution1.c
@@ -1,14 +1,39 @@
 #include "minishell.h"
 
+void    wait_childs(pid_t *pid)
+{
+    int i;
+    int status;
+
+    i = -1;
+    while(++i < (int)getcore()->cmd_count)
+        waitpid(pid[i], &status, 0);
+    getcore()->exit_code = WEXITSTATUS(status);
+}
+
 void    exec_cmdparent(void *data, pid_t pid)
 {
     int status;
     int *i;
+    int signal ;
 
+    signal = 0;
     i = (int *)data;
-    getcore()->pids[*i] = pid;
-    waitpid(pid, &status, 0);
-    getcore()->exit_code = WEXITSTATUS(status);
+    if (i)
+    {
+        getcore()->pids[*i] = pid;
+        if (*i + 1 == (int)getcore()->cmd_count)
+            wait_childs(getcore()->pids);
+        return ;
+    }
+        wait(&status);
+        if (WIFSIGNALED(status))
+        {
+            signal = WTERMSIG(status) + 128;
+            if (WTERMSIG(status) == SIGSEGV)
+                ft_putstr_fd("Segmentation fault (core dumped)\n", 2);
+        }
+        getcore()->exit_code = WEXITSTATUS(status) + signal;
 }
 
 void    exec_cmdchild(void *data)

--- a/source/execution/redirections/redirection.c
+++ b/source/execution/redirections/redirection.c
@@ -1,5 +1,21 @@
 #include "minishell.h"
 
+static void    redirection_cleanup(t_lx *lexer, int ifd, int ofd)
+{
+    char *str;
+
+    if (ifd > 2)
+        close(ifd);
+    if (ofd > 2)
+        close(ofd);
+    close_allhd(lexer);
+    if (lexer->type == AMBIG_RDRT)
+    {
+        str = ft_strjoin(ft_strjoin(": ", lexer->next->content), AMBIG_ERR);
+        pexit(str, AMBIG_CODE, 0);
+    }
+}
+
 int     redirection(char *filename, char mode, int oldfd)
 {
     if (oldfd > 2)
@@ -14,7 +30,7 @@ int     redirection(char *filename, char mode, int oldfd)
         return (ofd(filename, mode));
 }
 
-static bool prepare_heredoc(t_cmd *cmd_list)
+bool prepare_heredoc(t_cmd *cmd_list)
 {
     int fd;
     t_lx *lexer;
@@ -28,7 +44,7 @@ static bool prepare_heredoc(t_cmd *cmd_list)
             {
                 fd = redirection(lexer->next->content, lexer->type, 0);
                 if (fd < 0)
-                    return (false);
+                    return (close_allhd(getcore()->lexer), false);
                 clear_1data(lexer->next->content);
                 lexer->type = HERE_DOC_FD;
                 lexer->next->content = ft_itoa(fd);
@@ -47,16 +63,16 @@ bool    prepare_ifof(t_cmd *cmd_list)
     lexer = cmd_list->scope;
     if (cmd_list->unsed_fd > 2)
         close(cmd_list->unsed_fd);
-    if (!prepare_heredoc(cmd_list))
-        return (false);
     while (lexer)
     {   
+        if (lexer->type == AMBIG_RDRT)
+            return (redirection_cleanup(lexer, cmd_list->ifd, cmd_list->ofd), false);
         if (lexer->type == IN_RDRT || lexer->type == HERE_DOC_FD)
             cmd_list->ifd = redirection(lexer->next->content, lexer->type, cmd_list->ifd);
         else if (lexer->type == OUT_RDRT_APP || lexer->type == OUT_RDRT_OW)
             cmd_list->ofd = redirection(lexer->next->content, lexer->type, cmd_list->ofd);
         if (cmd_list->ofd < 0 || cmd_list->ifd < 0)
-            return (close_allhd(lexer), false);
+            return (redirection_cleanup(lexer, cmd_list->ifd, cmd_list->ofd), false);
         lexer = lexer->next;
     }
     if (!duping(cmd_list->ifd, cmd_list->ofd))

--- a/source/execution/utils/utils.c
+++ b/source/execution/utils/utils.c
@@ -4,12 +4,11 @@ void close_allhd(t_lx *lexer)
 {
     while (lexer)
     {
-        if (lexer->type == HERE_DOC)
+        if (lexer->type == HERE_DOC_FD)
             close(atoi(lexer->next->content));
         lexer = lexer->next;
     }
 }
-
 
 bool backup_fd(int *fd)
 {

--- a/source/parser/cmd.c
+++ b/source/parser/cmd.c
@@ -63,7 +63,17 @@ void    final_touch(t_lx *lexer)
 
     while (lexer)
     {
-        if (havequotes(lexer))
+        if (istoken(lexer->type, NON_PIPE) && lexer->type != HERE_DOC)
+        {
+            lexer = lexer->next;
+            if (!lexer->content[0] || checkspace_str(lexer->content))
+            {
+                clear_1data(lexer->content);
+                lexer->content = lexer->original_content;
+                lexer->prev->type = AMBIG_RDRT;
+            }
+        }
+        else if (havequotes(lexer))
         {
             new_str = getnewstr(lexer->content);
             clear_1data(lexer->content);

--- a/source/parser/env.c
+++ b/source/parser/env.c
@@ -1,5 +1,6 @@
 #include "minishell.h"
 
+
 void    update_env(t_env *env_list)
 {
     t_ndx i;
@@ -17,6 +18,7 @@ void    update_env(t_env *env_list)
     while (env_list)
     {
         getcore()->env[i.i++] = ft_strjoin_m(ft_strjoin_m(env_list->key, "="), env_list->value);
+        env_list = env_list->next;
     }
 }
 
@@ -52,4 +54,5 @@ void   fill_env_list(char *env[])
         addtolist(env_node, "t_env", NULL);
     }
     ft_update_path();
+    update_env(getcore()->env_list);
 }

--- a/source/parser/expanding.c
+++ b/source/parser/expanding.c
@@ -60,7 +60,6 @@ char    *expand_dollar(char *line)
     }
     strocpy(&expline[ft_strlen(expline)], list->content, -1);
     strocpy(&expline[ft_strlen(expline)], &line[list->end_ndx], -1);
-    clear_1data(line);
     clear_1list(list, "t_var");
     return (expline);
 }
@@ -72,9 +71,10 @@ void    expanding(t_lx *lexer)
 
     while (lexer)
     {
-        if (lexer->type == WORD && needexpand(lexer->content))
+        if (needexpand(lexer->content, lexer))
         {
             new_content = expand_dollar(lexer->content);
+            lexer->original_content = lexer->content;
             lexer->content = ft_strtrim(new_content, IS_SPACE); 
             clear_1data(new_content);
         }

--- a/source/parser/parsing.c
+++ b/source/parser/parsing.c
@@ -7,6 +7,8 @@ void    reader_loop(void)
     while (true)
     {
         line = readline("Eurika ✨➜ ");
+        if (getcore()->sig_init || getcore()->sig_init)
+            continue;
         if (!line)
             (clear(FREE_ALL), exit(getcore()->exit_code));
         if (line[0] == 0 || ft_isspace(0, line))
@@ -16,8 +18,7 @@ void    reader_loop(void)
             continue;
         }
         getcore()->in_line = line;
-        gc_add_node(line);
-        add_history(line);
+        (gc_add_node(line), add_history(line));
         break ;
     }
 }
@@ -30,19 +31,11 @@ bool    parsing(void)
     core->inline_len = ft_strlen(core->in_line);
     if (!check_quotes(core->in_line) || !lexing(core->in_line))
         return (false);
-    if (needexpand(core->in_line))
+    if (needexpand(core->in_line, NULL))
         expanding(core->lexer);
     final_touch(core->lexer); // remove all kind of quotes in begging or in middle 
-    
-    // printf(BOLD_MAGENTA "╔══════════════════════════════════════════════════════╗\n");
-    // printf("║              PARSER: AFTER FINAL TOUCH               ║\n");
-    // printf("╚══════════════════════════════════════════════════════╝\n" END);
-    // print_lx();
-    
     load_cmd_list(core);
-
-    // printf(BOLD_CYAN "\n╔═══════════════════ COMMAND LIST ═══════════════════╗\n");
-    // printf("║         Displaying parsed command structure         ║\n");
-    // printf("╚════════════════════════════════════════════════════╝\n" END);
+    if (!prepare_heredoc(core->cmd))
+        return (false);
     return (true);
 }

--- a/source/utils/utils_lst.c
+++ b/source/utils/utils_lst.c
@@ -78,5 +78,10 @@ void    *getlastnode(void *list, char *list_type)
         while (((t_lx *)list)->next)
             list = ((t_lx *)list)->next;
     }
+    else if ((list && !ft_strncmp(list_type, "t_env", -1)))
+    {
+        while (((t_env *)list)->next)
+            list = ((t_env *)list)->next;
+    }
      return (list);
 }

--- a/source/utils/utils_lst.c
+++ b/source/utils/utils_lst.c
@@ -78,7 +78,7 @@ void    *getlastnode(void *list, char *list_type)
         while (((t_lx *)list)->next)
             list = ((t_lx *)list)->next;
     }
-    else if ((list && !ft_strncmp(list_type, "t_env", -1)))
+    else if (list && !ft_strncmp(list_type, "t_env", -1))
     {
         while (((t_env *)list)->next)
             list = ((t_env *)list)->next;

--- a/source/utils/utils_r0.c
+++ b/source/utils/utils_r0.c
@@ -22,11 +22,16 @@ int     get_dollar(char *str, bool *flag)
     return (i);
 }
 
-bool    needexpand(char *str)
+bool    needexpand(char *str, t_lx *lexer)
 {
     int i;
 
     i = -1;
+    if (lexer && lexer->type == WORD)
+    {
+        if (lexer->prev && lexer->prev->type == HERE_DOC)
+            return(false);
+    }
     while (str && str[++i])
     {
         if (str[i] == '$' && str[i + 1] && !ft_isspace(str[i + 1], NULL))

--- a/source/utils/utils_r2.c
+++ b/source/utils/utils_r2.c
@@ -37,7 +37,7 @@ static char	*ft_csubstr(char const *s, unsigned int start, size_t len)
 	return (sub);
 }
 
-char    *strchrdup(char *str, char *delimit, bool type)
+char    *strchrdup(const char *str, char *delimit, bool type)
 {
     int i;
 


### PR DESCRIPTION
This pull request includes various changes to the `minishell` project, focusing on error handling, memory management, and code refactoring. The most important changes include adding new error codes and handling ambiguous redirection, updating structures to include additional fields, and refactoring functions to improve readability and maintainability.

### Error Handling Improvements:
* Added `AMBIG_RDRT` token type and `AMBIG_CODE` error code to handle ambiguous redirection errors (`includes/macros.h`). [[1]](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1L77-R83) [[2]](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1R105)
* Defined `AMBIG_ERR` macro for ambiguous redirection error messages (`includes/macros.h`).

### Structure Updates:
* Added `original_content` field to `t_lx` structure to store the original content of tokens (`includes/minishell.h`).
* Added `sig_init` and `sig_quit` fields to `t_all` structure to handle signal states (`includes/minishell.h`).

### Function Refactoring:
* Modified `prepare_heredoc` and `prepare_ifof` functions to improve error handling and cleanup (`source/execution/redirections/redirection.c`). [[1]](diffhunk://#diff-39293d4b87bd25f6559e0f71bb3311ca4d00296066a5ef07e2ac99cd527e5db9L17-R33) [[2]](diffhunk://#diff-39293d4b87bd25f6559e0f71bb3311ca4d00296066a5ef07e2ac99cd527e5db9L50-R75)
* Refactored `parse_key_value` function to remove return values and use `strchrdup` for memory allocation (`source/execution/builtin/ft_export.c`).
* Added `update_env_value` function to handle environment variable updates and refactored `ft_setenv` to use it (`source/execution/builtin/ft_unset.c`). [[1]](diffhunk://#diff-2e4188e4fc27071c202198f6ae6081d24fd1d911d893763c5b8877af54db3060L39-R59) [[2]](diffhunk://#diff-2e4188e4fc27071c202198f6ae6081d24fd1d911d893763c5b8877af54db3060L61-R94)

### Code Simplification:
* Simplified `exec_cmdparent` function to handle signal states and exit codes more cleanly (`source/execution/execution1.c`).
* Removed unnecessary `clear_1data` call in `expand_dollar` function to avoid double free issues (`source/parser/expanding.c`).

These changes collectively enhance the robustness and maintainability of the `minishell` project.