### PR TITLE
Fix/shell bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,14 @@ VALGRIND_CMD = valgrind \
     --suppressions=readline.supp \
     --leak-check=full \
     --show-leak-kinds=all \
-    --track-fds=yes \
     --track-origins=yes \
     --error-limit=no \
     --trace-children=yes \
     --child-silent-after-fork=no \
     --num-callers=50 \
-    --expensive-definedness-checks=yes \
     --malloc-fill=0x42 \
     --free-fill=0x43 \
-    ./minishell
+	./minishell
 
 ASAN_CMD = ASAN_OPTIONS=detect_leaks=1 ./minishell
 

--- a/includes/macros.h
+++ b/includes/macros.h
@@ -104,7 +104,7 @@ typedef enum e_error_code
     READLINE_CODE,       /**< Error code for readline() function failure */
     AMBIG_CODE = 20,     /**< Error code for ambiguous redirection */
     PERM_DENIED_CODE = 126,   /**< Permission denied (not executable) */
-    CMD_NOT_FOUND_CODE = 127, /**< Command not found in PATH */
+    CMD_NOTFOUND_CODE = 127, /**< Command not found in PATH */
     SIGTERM_CODE = 143,  /**< Termination signal error code */
     SIGXCPU_CODE = 24    /**< CPU time limit exceeded signal error code */
 } t_error_code;

--- a/source/execution/builtin/ft_cd.c
+++ b/source/execution/builtin/ft_cd.c
@@ -1,6 +1,3 @@
-
-
-
 #include "minishell.h"
 
 static void update_env_cwd(char *oldpwd)
@@ -12,8 +9,8 @@ static void update_env_cwd(char *oldpwd)
         pexit("cd: getcwd", 1, 0); 
         return ;
     }
-    ft_setenv("OLDPWD", oldpwd, 1);
-    ft_setenv("PWD", cwd, 1);
+    ft_setenv("OLDPWD", strchrdup(oldpwd, NULL, CALLOC), 1);
+    ft_setenv("PWD", strchrdup(cwd, NULL, CALLOC), 1);
 }
 
 static int cha_dir(char *dir)

--- a/source/execution/builtin/ft_exit.c
+++ b/source/execution/builtin/ft_exit.c
@@ -1,13 +1,11 @@
-
-
-
-
-
 #include "minishell.h"
 
 
-void    ft_exit(t_cmd *cmd)
+void    ft_exit(char **cmd)
 {
     (void)cmd;
-    printf("is exit\n");
+    //to be done
+
+
+    printf("exit\n");
 }

--- a/source/execution/execution.c
+++ b/source/execution/execution.c
@@ -31,10 +31,10 @@ void  exec_ncmd(t_cmd *cmd)
     {
         if (forker(exec_cmdchild, cmd, exec_cmdparent, &i) < 0)
             return (pexit("fork", FORK_CODE, 0), (void)0);
-        close(pip[WRITE_END]);
         cmd = cmd->next;
         if (!cmd)
             return (close(pip[READ_END]), (void)0);
+        close(pip[WRITE_END]);
         cmd->ifd = pip[READ_END];
         if (i++ + 2 < getcore()->cmd_count)
         {
@@ -90,7 +90,7 @@ void load_cmd(t_cmd *cmd_list)
 // exitcode formula (exit_code % 256 + 256) % 256 == exit_code & 0xFF
 void    execution(void)
 {
-    // print_cmd();
+    print_cmd();
     if (getcore()->cmd_count == 1)
         exec_1cmd(getcore()->cmd);
     else

--- a/source/execution/execution1.c
+++ b/source/execution/execution1.c
@@ -49,11 +49,13 @@ void    exec_cmdchild(void *data)
     if (cmd->cmd && !is_builtin(cmd->cmd[0]))
     {
         cmdpath = getcmdpath(cmd->cmd[0]);
+        if (!cmdpath)
+            (close(STDIN_FILENO), close(STDOUT_FILENO), clear(FREE_ALL), exit(getcore()->exit_code));
         execve(cmdpath, cmd->cmd, getcore()->env);
         (close(cmd->ifd), close(cmd->ofd));
         pexit("execve", 1, EXIT);
     }
     exitcode = exec_builtin(cmd);
-    (close(cmd->ifd), close(cmd->ofd));
+    (close(STDIN_FILENO), close(STDOUT_FILENO));
     (clear(FREE_ALL), exit(exitcode));
 }

--- a/source/execution/redirections/hd.c
+++ b/source/execution/redirections/hd.c
@@ -1,5 +1,15 @@
 #include "minishell.h"
 
+static char getunique(void)
+{
+    static char num;
+
+    if (num == 90)
+        num = 0;
+    num += 65;
+    return (num);
+}
+
 static bool hd_handleline(char *line, char *delimit, int fd, unsigned int count)
 {
     if (!line)
@@ -39,6 +49,7 @@ int hd(char *delimit)
     char    *tmpfile;
 
     tmpfile = ft_strjoin("/tmp/hdtmp.", ft_itoa(getpid()));
+    tmpfile[ft_strlen(tmpfile) - 1] = getunique();
     if (hd_reader_loop(tmpfile, delimit) == 1)
         return(-1);
     fd = open(tmpfile, O_RDONLY);

--- a/source/parser/env.c
+++ b/source/parser/env.c
@@ -5,6 +5,7 @@ void    update_env(t_env *env_list)
 {
     t_ndx i;
     t_env *tmp;
+    char *tmpstr;
 
     ft_bzero(&i, sizeof(t_ndx));
     tmp = env_list;
@@ -17,7 +18,9 @@ void    update_env(t_env *env_list)
     getcore()->env = ft_calloc(i.l + 1, sizeof(char *));
     while (env_list)
     {
-        getcore()->env[i.i++] = ft_strjoin_m(ft_strjoin_m(env_list->key, "="), env_list->value);
+        tmpstr = ft_strjoin_m(env_list->key, "=");
+        getcore()->env[i.i++] = ft_strjoin_m(tmpstr, env_list->value);
+        free(tmpstr);
         env_list = env_list->next;
     }
 }


### PR DESCRIPTION
This pull request includes various changes to improve code readability, fix bugs, and enhance functionality in the minishell project. The most important changes include modifications in the `Makefile`, updates to error handling and environment variable management, and improvements to command execution.

### Code readability and maintenance:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-L46): Removed unnecessary Valgrind options to simplify the command.
* [`includes/macros.h`](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1L107-R107): Renamed `CMD_NOT_FOUND_CODE` to `CMD_NOTFOUND_CODE` for consistency.

### Bug fixes:
* [`source/execution/builtin/ft_cd.c`](diffhunk://#diff-e2eb9bb592d7d76923c6f008e32db8ad32417628113716804369446e76bb6a32L15-R13): Updated `ft_setenv` calls to use `strchrdup` for better memory management.
* [`source/execution/execution.c`](diffhunk://#diff-24d4d443d12bc3da7d33f3222b0f7b70d6ec72db137b3d8aaa46f9031c0c4912L34-R37): Fixed the order of `close(pip[WRITE_END])` to ensure proper resource cleanup.

### Functionality enhancements:
* [`source/execution/redirections/hd.c`](diffhunk://#diff-b04bcb23e44faa6e0879015b6e314382083f8ade6a3716cdaaa3f5dfb0608102R3-R12): Added `getunique` function to generate unique temporary file names.
* [`source/parser/env.c`](diffhunk://#diff-9d272fd8a5b14d6d7bf4e54ad8f10aab10b11d14e9f7160f157866572538aefbL20-R23): Improved environment update logic by using a temporary string to prevent memory leaks.