### PR TITLE
Fix env , export, syntax error exit_status, with additional code improvement 

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -144,6 +144,11 @@ typedef enum e_token_check_mode {
     ALL_TKN = 1    /**< Check all tokens including pipe token */
 } t_token_check_mode;
 
+typedef enum e_overwrite_mode {
+    NO_OVERWRITE = 0,  /**< Do not overwrite the existing value */
+    OVERWRITE = 1,     /**< Overwrite the existing value with the new value */
+    APPEND = 2         /**< Append the new value to the existing value using `+=` */
+} t_overwrite_mode;
 
 //for all whitespace charachters
 # define IS_SPACE " \t\v\n\r\f"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -211,7 +211,7 @@ int     ft_unset(t_cmd *cmd);
 int     ft_exit(char **cmd);
 
 /*          builtin utils               */
-int     ft_setenv(char *name, char *val, int overwrite);
+void     ft_setenv(char *name, char *val, int overwrite);
 char    *ft_getenv(char *var);
 
 

--- a/source/execution/builtin/ft_echo.c
+++ b/source/execution/builtin/ft_echo.c
@@ -5,8 +5,10 @@
 static size_t is_flag(char *prompt, int * flag_found)
 {
     size_t i;
+    int old_flag;
 
     i = 0;
+    old_flag = *flag_found;
     if (ft_strncmp(prompt, "-n",2) == 0)
     {
         *flag_found = 1;
@@ -15,7 +17,8 @@ static size_t is_flag(char *prompt, int * flag_found)
             i++;
         if (prompt[i] != 0)
         {
-            *flag_found = 0;
+            if (!old_flag)
+                *flag_found = 0;
             return (0);
         }
     }

--- a/source/execution/builtin/ft_env.c
+++ b/source/execution/builtin/ft_env.c
@@ -27,7 +27,8 @@ int    ft_env()
         return (1);
     while (env)
     {
-        printf("%s=%s\n", env->key, env->value);
+        if (env->value)
+            printf("%s=%s\n", env->key, env->value);
         env = env->next;
     }
     return (0);

--- a/source/execution/builtin/ft_export.c
+++ b/source/execution/builtin/ft_export.c
@@ -38,7 +38,7 @@ static void parse_key_value(const char *arg, char **key, char **value)
     equal_sign_pos = ft_strchr(arg, '=');
     if (!equal_sign_pos)
     {
-        *key = ft_strdup(arg);
+        *key = strchrdup(arg, NULL, CALLOC);
         *value = NULL;
         return ;
     }

--- a/source/execution/builtin/ft_export.c
+++ b/source/execution/builtin/ft_export.c
@@ -56,9 +56,9 @@ static int ft_add_export(char *arg, bool has_plus)
 
     parse_key_value(arg, &key, &value);
     if (value && has_plus)
-        ft_setenv(key, value, 2); 
+        ft_setenv(key, value, APPEND); 
     else
-        ft_setenv(key, value, 1); 
+        ft_setenv(key, value, OVERWRITE); 
     return (1);
 }
 

--- a/source/execution/builtin/ft_unset.c
+++ b/source/execution/builtin/ft_unset.c
@@ -43,31 +43,30 @@ static void update_env_value(t_env *env, char *val, int overwrite)
 {
     char *tmp;
 
-    if ((overwrite == 2) && val)
+    if ((overwrite == APPEND) && val)
     {
         tmp = env->value;
         env->value = ft_strjoin_m(env->value, val);
         free(tmp);
         free(val);
     }
-    else if (overwrite == 1 && val)
+    else if (overwrite == OVERWRITE && val)
     {
         free(env->value);
         env->value = val;
     }
 }
-
-/**  @brief same as the orignal setenv(3), 
-*    except tar9i3a of overwrite == 2 
-*    for appending env variable with += 
-*      
-*   @param overwrite Determines the behavior when the variable already exists:
-*                  - 0: Do not overwrite the existing value.
-*                  - 1: Overwrite the existing value with the new value.
-*                  - 2: Append the new value to the existing value using `+=`. 
-*   @return 1 on success, 0 on failure.
-*/
-int     ft_setenv(char *key, char *val, int overwrite)
+/**
+ * @brief Sets or updates an environment variable
+ * @details Same as the original setenv(3), except for overwrite == APPEND for appending env variable with `+=`
+ * @param key Name of the environment variable
+ * @param val Value of the environment variable
+ * @param overwrite Determines the behavior when the variable already exists:
+ *                  - NO_OVERWRITE: Do not overwrite the existing value.
+ *                  - OVERWRITE: Overwrite the existing value with the new value.
+ *                  - APPEND: Append the new value to the existing value using `+=`.
+ */
+void     ft_setenv(char *key, char *val, int overwrite)
 {
     t_env *env;
     bool found;

--- a/source/execution/builtin/ft_unset.c
+++ b/source/execution/builtin/ft_unset.c
@@ -56,6 +56,7 @@ static void update_env_value(t_env *env, char *val, int overwrite)
         env->value = val;
     }
 }
+
 /**
  * @brief Sets or updates an environment variable
  * @details Same as the original setenv(3), except for overwrite == APPEND for appending env variable with `+=`
@@ -79,16 +80,15 @@ void     ft_setenv(char *key, char *val, int overwrite)
         {
             update_env_value(env, val, overwrite);
             found = true;
-            break;
+            return ;
         }
         env = env->next;
     }
     if (!found)
     {
         if (ft_add_node(getlastnode(getcore()->env_list, "t_env"), key, val) == 0)
-            return (1);
+            return ;
     }
-    return (0);
 }
 
 

--- a/source/parser/lexer.c
+++ b/source/parser/lexer.c
@@ -4,7 +4,7 @@ static  bool checklastnode(t_lx *lastnode)
 {
     if (istoken(lastnode->type, ALL_TKN))
     {
-        pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, lastnode->content), "'"), 1, 0);
+        pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, lastnode->content), "'"), 2, 0);
         return (false);
     }
     return(true);
@@ -50,9 +50,9 @@ static long long lexer_add_token(char type)
     lexer->content = strtkr_gen(type);
     prev_nd = (t_lx *)getlastnode(getcore()->lexer, "t_lx");
     if (!prev_nd && lexer->type == PIPE)
-        pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, "|"), "'"), 1, 0);
+        pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, "|"), "'"), 2, 0);
     else if (prev_nd && istoken(prev_nd->type, NON_PIPE))
-        pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, prev_nd->content), "'"), 1, 0);
+        pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, prev_nd->content), "'"), 2, 0);
     addtolist(lexer, "t_lx", NULL);
     if (type == PIPE)
         getcore()->pipe_count++;


### PR DESCRIPTION
This pull request includes several changes to improve the handling of environment variables, error handling, and token processing in the codebase. The most important changes include the addition of a new enum for overwrite modes, modifications to the `ft_setenv` function, and updates to error handling in the lexer.

### Improvements to environment variable handling:

* [`includes/macros.h`](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1R147-R151): Added a new enum `e_overwrite_mode` to define modes for handling environment variable overwrites (`NO_OVERWRITE`, `OVERWRITE`, `APPEND`).
* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL214-R214): Changed the return type of `ft_setenv` from `int` to `void` to reflect its updated functionality.
* [`source/execution/builtin/ft_export.c`](diffhunk://#diff-d247ae7d318175adb3d8e28b9575b5635aea502be3e9a0e4697c2709be552f62L59-R61): Updated `ft_add_export` to use the new `APPEND` and `OVERWRITE` modes from the `e_overwrite_mode` enum.
* [`source/execution/builtin/ft_unset.c`](diffhunk://#diff-2e4188e4fc27071c202198f6ae6081d24fd1d911d893763c5b8877af54db3060L46-R70): Modified `update_env_value` and `ft_setenv` to handle the new overwrite modes and updated the function documentation accordingly. [[1]](diffhunk://#diff-2e4188e4fc27071c202198f6ae6081d24fd1d911d893763c5b8877af54db3060L46-R70) [[2]](diffhunk://#diff-2e4188e4fc27071c202198f6ae6081d24fd1d911d893763c5b8877af54db3060L83-L92)

### Enhancements to error handling:

* [`source/parser/lexer.c`](diffhunk://#diff-bb3b254ff09141bb60a2a6f6519af325de4cb09a6bd05934e77dd31299567e51L7-R7): Updated the error handling in `checklastnode` and `lexer_add_token` to use a different error code (`2` instead of `1`). [[1]](diffhunk://#diff-bb3b254ff09141bb60a2a6f6519af325de4cb09a6bd05934e77dd31299567e51L7-R7) [[2]](diffhunk://#diff-bb3b254ff09141bb60a2a6f6519af325de4cb09a6bd05934e77dd31299567e51L53-R55)

### Other changes:

* [`source/execution/builtin/ft_echo.c`](diffhunk://#diff-5995943ffa1c4d9182482d64c92a320322dd1a610b7c5d0b2476e6719338046dR8-R11): Added a variable `old_flag` to improve flag handling in the `is_flag` function. [[1]](diffhunk://#diff-5995943ffa1c4d9182482d64c92a320322dd1a610b7c5d0b2476e6719338046dR8-R11) [[2]](diffhunk://#diff-5995943ffa1c4d9182482d64c92a320322dd1a610b7c5d0b2476e6719338046dR20)
* [`source/execution/builtin/ft_env.c`](diffhunk://#diff-c493150167370d8246d46b38a9e7fb7a773f7802e161d294e0447ec15d008efaR30): Added a check to ensure that environment variables with `NULL` values are not printed.
* [`source/execution/builtin/ft_export.c`](diffhunk://#diff-d247ae7d318175adb3d8e28b9575b5635aea502be3e9a0e4697c2709be552f62L41-R41): Replaced `ft_strdup` with `strchrdup` for key duplication in `parse_key_value`.