### PR TITLE
Fix/final bugs

### DIFF
--- a/includes/ext_libs.h
+++ b/includes/ext_libs.h
@@ -22,6 +22,7 @@
 # include <signal.h>
 # include <unistd.h>
 # include <sys/types.h>
+#include <sys/stat.h>
 
 
 typedef unsigned char	t_uc; //just a macro that i used in libft to avoid long line on norminette ;)

--- a/includes/macros.h
+++ b/includes/macros.h
@@ -104,9 +104,8 @@ typedef enum e_error_code
     READLINE_CODE,       /**< Error code for readline() function failure */
     AMBIG_CODE = 20,     /**< Error code for ambiguous redirection */
     PERM_DENIED_CODE = 126,   /**< Permission denied (not executable) */
-    CMD_NOTFOUND_CODE = 127, /**< Command not found in PATH */
-    SIGTERM_CODE = 143,  /**< Termination signal error code */
-    SIGXCPU_CODE = 24,    /**< CPU time limit exceeded signal error code */
+    CMD_NOTFOUND_CODE = 127,  /**< Command not found in PATH */
+    SIG_BASE_CODE = 128,      /**< Base signal code (exit = 128 + signal_number) */
     GNRL_CODE = 1
 } t_error_code;
 
@@ -172,6 +171,9 @@ typedef enum e_token_check_mode {
 
 //macro for cmd permition denied
 #define PERM_DENIED ": permission denied !"
+
+//macro for cmd if is a dirrectory
+#define CMD_DIR ": Is a directory !"
 
 //macro pexit func to exit ot not
 # define EXIT 1

--- a/source/parser/lexer.c
+++ b/source/parser/lexer.c
@@ -49,7 +49,7 @@ static long long lexer_add_token(char type)
     lexer->type = type;
     lexer->content = strtkr_gen(type);
     prev_nd = (t_lx *)getlastnode(getcore()->lexer, "t_lx");
-    if (!prev_nd && lexer->type == PIPE)
+    if (lexer->type == PIPE && (!prev_nd || (prev_nd && prev_nd->type == PIPE)))
         pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, "|"), "'"), 1, 0);
     else if (prev_nd && istoken(prev_nd->type, NON_PIPE))
         pexit(ft_strjoin(ft_strjoin(TOKEN_ERR, prev_nd->content), "'"), 1, 0);
@@ -57,8 +57,8 @@ static long long lexer_add_token(char type)
     if (type == PIPE)
         getcore()->pipe_count++;
     if (type == HERE_DOC || type == OUT_RDRT_APP)
-        return (2); //skip the token by 2 in case of '<<' or '>>'
-    return (1); //skip the token by 1 in case or '<' or '>'
+        return (2);
+    return (1);
 }
 
 bool    lexing(char *line)

--- a/source/utils/signals.c
+++ b/source/utils/signals.c
@@ -15,6 +15,7 @@ static void sigint_handler(int sig)
         rl_replace_line("", 0);
         rl_redisplay();
     }
+    getcore()->exit_code = SIG_BASE_CODE + sig;
     (void)sig;
 }
 
@@ -23,22 +24,17 @@ void sighandler()
     struct sigaction act_int;
     struct sigaction act_quit;
 
-    // Initialize the entire structs to 0
     ft_bzero(&act_int, sizeof(act_int));
     ft_bzero(&act_quit, sizeof(act_quit));
 
-    // Set up SIGINT (Ctrl+C) handler
     act_int.sa_handler = sigint_handler;
     sigemptyset(&act_int.sa_mask);
-    act_int.sa_flags = 0; // Remove SA_SIGINFO as we don't need it
-
-    // Set up SIGQUIT (Ctrl+\) handler - completely ignore
-    act_quit.sa_handler = SIG_IGN; // Use SIG_IGN instead of custom handler
+    act_int.sa_flags = 0;
+    act_quit.sa_handler = SIG_IGN;
     sigemptyset(&act_quit.sa_mask);
     act_quit.sa_flags = 0; 
 
-    if (sigaction(SIGINT, &act_int, NULL) == -1)
-        pexit("sigaction()", EXIT_FAILURE, 1);
-    if (sigaction(SIGQUIT, &act_quit, NULL) == -1)
+    if (sigaction(SIGINT, &act_int, NULL) == -1 ||
+        sigaction(SIGQUIT, &act_quit, NULL) == -1)
         pexit("sigaction()", EXIT_FAILURE, 1);
 }

--- a/source/utils/utils_r0.c
+++ b/source/utils/utils_r0.c
@@ -34,7 +34,7 @@ bool    needexpand(char *str, t_lx *lexer)
     }
     while (str && str[++i])
     {
-        if (str[i] == '$' && str[i + 1] && !ft_isspace(str[i + 1], NULL))
+        if (str[i] == '$' && (str[i + 1] && (ft_isalpha((int)str[i + 1]) || str[i + 1] == '?')))
             return (true);
     }
     return (false);


### PR DESCRIPTION
This pull request includes several changes to improve error handling, signal management, and code readability. The most important changes include adding directory handling in the command path check, updating signal handling, and refining token processing in the lexer.

### Error Handling Improvements:
* [`includes/ext_libs.h`](diffhunk://#diff-238c7919b77b3b372d3831ba3a3e5e7b8642f4b1b96c195e0d778d65507d9fd7R25): Included the `<sys/stat.h>` library to enable file status checks.
* [`includes/macros.h`](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1R175-R177): Added a macro for handling the case when a command is a directory (`CMD_DIR`).
* [`source/execution/utils/utils.c`](diffhunk://#diff-d5097c2e524cb1a8450a3b5fcd461641d4ec9891dd323c5f00044c82985fc36aL52-R66): Modified `checkpathcase0` to handle directories and updated `getcmdpath` to pass the new directory error message. [[1]](diffhunk://#diff-d5097c2e524cb1a8450a3b5fcd461641d4ec9891dd323c5f00044c82985fc36aL52-R66) [[2]](diffhunk://#diff-d5097c2e524cb1a8450a3b5fcd461641d4ec9891dd323c5f00044c82985fc36aR79-R84)

### Signal Handling Enhancements:
* [`includes/macros.h`](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1L108-R108): Replaced specific signal error codes with a base signal code (`SIG_BASE_CODE`).
* [`source/utils/signals.c`](diffhunk://#diff-a3e4129845f6e137806373d4e5f37a1421134d8765ac72aab48c7039462350e3R18): Updated `sigint_handler` to set the exit code based on the signal received and simplified the `sighandler` function. [[1]](diffhunk://#diff-a3e4129845f6e137806373d4e5f37a1421134d8765ac72aab48c7039462350e3R18) [[2]](diffhunk://#diff-a3e4129845f6e137806373d4e5f37a1421134d8765ac72aab48c7039462350e3L26-R38)

### Lexer Token Processing:
* [`source/parser/lexer.c`](diffhunk://#diff-bb3b254ff09141bb60a2a6f6519af325de4cb09a6bd05934e77dd31299567e51L52-R61): Refined the condition for adding a pipe token to handle consecutive pipes correctly.

### Miscellaneous:
* [`source/utils/utils_r0.c`](diffhunk://#diff-a51046d02a3c84dbecc27f73517d09906f61b2411850831a7321242fc75bc6cdL37-R37): Updated the `needexpand` function to correctly identify variables and special characters for expansion.