### PR TITLE
Fix/final bugs

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -189,6 +189,9 @@ typedef enum e_overwrite_mode {
 // exit built in right usage
 # define EXIT_USAGE ": exit: usage: exit [N]\nN must be >= 0 and <= 255"
 
+//macros for signal handler
+# define SG_HD_MODE 1
+
 // Regular text colors
 #define BLACK "\033[0;30m"
 #define RED "\033[0;31m"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -250,7 +250,7 @@ char        *strchrdup(const char *str, char *delimit, bool type);
 void        *getlastnode(void *list, char *list_type);
 t_lx        *splitcontent(char *str);
 void        ft_update_path(void);
-void        sighandler();
+void        sighandler(bool mode);
 
 
 

--- a/source/execution/redirections/redirection.c
+++ b/source/execution/redirections/redirection.c
@@ -44,7 +44,7 @@ bool prepare_heredoc(t_cmd *cmd_list)
             {
                 fd = redirection(lexer->next->content, lexer->type, 0);
                 if (fd < 0)
-                    return (close_allhd(getcore()->lexer), false);
+                    return (close_allhd(getcore()->lexer), 1);
                 clear_1data(lexer->next->content);
                 lexer->type = HERE_DOC_FD;
                 lexer->next->content = ft_itoa(fd);
@@ -53,7 +53,7 @@ bool prepare_heredoc(t_cmd *cmd_list)
         }
         cmd_list = cmd_list->next;
     }
-    return (true);
+    return (0);
 }
 
 bool    prepare_ifof(t_cmd *cmd_list)

--- a/source/execution/utils/utils.c
+++ b/source/execution/utils/utils.c
@@ -33,36 +33,37 @@ static char checkpathcase1(char *cmd, char *not_found, char *perm_denied, char *
 {
     char **path; 
     int i;
+    struct stat path_stat;
 
     path = getcore()->path;
     i = -1;
     while (path[++i])
     {
         *returnpath = ft_strjoin(path[i], cmd);
-        if (access(*returnpath, F_OK) == 0)
+        if (stat(*returnpath, &path_stat) == 0 && !S_ISDIR(path_stat.st_mode))
         {
-            if (access(*returnpath, F_OK) == 0)
-                return(0);
-            return(pexit(perm_denied, PERM_DENIED_CODE, 0), 1);
+            if (!(path_stat.st_mode & S_IXUSR))
+                return (pexit(perm_denied, PERM_DENIED_CODE, 0), 2);
+            return(0);
         }
     }
     return(pexit(not_found, CMD_NOTFOUND_CODE, 0), 2);
 }
 
-static char checkpathcase0(char *path, char *not_found, char *perm_denied, char *isdir)
+static char checkpathcase0(char *path, char *perm_denied)
 {
     struct stat path_stat;
+    char *isdir;
+    char *no_file;
 
-    if (!*path)
-        return (pexit(not_found, CMD_NOTFOUND_CODE, 0), 1);
+    no_file = ft_strjoin(ft_strjoin(": ", path), ": No such file or directory !");
+    isdir = ft_strjoin(ft_strjoin(": ", path), CMD_DIR);
     if (path[0] == '/' || path[0] == '.' || !getcore()->path)
     {
         if (stat(path, &path_stat) < 0)
-            return (pexit(not_found, CMD_NOTFOUND_CODE, 0), 1);
+            return (pexit(no_file, CMD_NOTFOUND_CODE, 0), 1);
         if (S_ISDIR(path_stat.st_mode))
             return (pexit(isdir, PERM_DENIED_CODE, 0), 2);
-        if (!S_ISREG(path_stat.st_mode))
-            return (pexit(not_found, CMD_NOTFOUND_CODE, 0), 1);
         if (!(path_stat.st_mode & S_IXUSR))
             return (pexit(perm_denied, PERM_DENIED_CODE, 0), 2);
         return (0);
@@ -76,12 +77,10 @@ char    *getcmdpath(char *cmd)
     char *not_found;
     char *perm_denied;
     char *fullpath;
-    char *isdir;
 
     not_found = ft_strjoin(ft_strjoin(": ", cmd), CMD_NOTFOUND);
     perm_denied = ft_strjoin(ft_strjoin(": ", cmd), PERM_DENIED);
-    isdir = ft_strjoin(ft_strjoin(": ", cmd), CMD_DIR);
-    res = checkpathcase0(cmd, not_found, perm_denied, isdir);
+    res = checkpathcase0(cmd, perm_denied);
     if (res == 0)
         return(cmd);
     if (res > 0)

--- a/source/minishell.c
+++ b/source/minishell.c
@@ -5,7 +5,7 @@ int main(int ac, char *av[], char *env[])
 	(void)ac;
 	(void)av;
 	fill_env_list(env);
-	sighandler();
+	sighandler(0);
 	while (true)
 	{
 		clear(FREE_TEMP);

--- a/source/parser/cmd.c
+++ b/source/parser/cmd.c
@@ -62,6 +62,7 @@ void    final_touch(t_lx *lexer)
     char *new_str;
     bool flag;
 
+    flag = 0;
     while (lexer)
     {
         if (lexer->type == WORD)

--- a/source/parser/parsing.c
+++ b/source/parser/parsing.c
@@ -32,7 +32,7 @@ bool    parsing(void)
         expanding(core->lexer);
     final_touch(core->lexer);
     load_cmd_list(core);
-    if (!prepare_heredoc(core->cmd))
+    if (prepare_heredoc(core->cmd) == 1)
         return (false);
     return (true);
 }

--- a/source/utils/signals.c
+++ b/source/utils/signals.c
@@ -1,5 +1,11 @@
 #include "minishell.h"
 
+static void sigint_handler_hd(int sig)
+{
+    clear(FREE_ALL);
+    exit(SIG_BASE_CODE + sig);
+}
+
 static void sigint_handler(int sig)
 {
     if (waitpid(-1, NULL, WNOHANG) == -1)
@@ -19,7 +25,7 @@ static void sigint_handler(int sig)
     (void)sig;
 }
 
-void sighandler()
+void sighandler(bool mode)
 {
     struct sigaction act_int;
     struct sigaction act_quit;
@@ -27,7 +33,10 @@ void sighandler()
     ft_bzero(&act_int, sizeof(act_int));
     ft_bzero(&act_quit, sizeof(act_quit));
 
-    act_int.sa_handler = sigint_handler;
+    if (mode == SG_HD_MODE)
+        act_int.sa_handler = sigint_handler_hd;
+    else
+        act_int.sa_handler = sigint_handler;
     sigemptyset(&act_int.sa_mask);
     act_int.sa_flags = 0;
     act_quit.sa_handler = SIG_IGN;

--- a/source/utils/signals.c
+++ b/source/utils/signals.c
@@ -2,6 +2,7 @@
 
 static void sigint_handler_hd(int sig)
 {
+    (void)sig;
     clear(FREE_ALL);
     exit(SIG_BASE_CODE + sig);
 }
@@ -10,14 +11,14 @@ static void sigint_handler(int sig)
 {
     if (waitpid(-1, NULL, WNOHANG) == -1)
     {
-        printf("\n");
+        write(1, "\n", 1);
         rl_on_new_line();
         rl_replace_line("", 0);
         rl_redisplay();
     }
     else
     {
-        printf("\n");
+        write(1, "\n", 1);
         rl_replace_line("", 0);
         rl_redisplay();
     }
@@ -33,16 +34,15 @@ void sighandler(bool mode)
     ft_bzero(&act_int, sizeof(act_int));
     ft_bzero(&act_quit, sizeof(act_quit));
 
+    sigemptyset(&act_int.sa_mask);
+    sigemptyset(&act_quit.sa_mask);
     if (mode == SG_HD_MODE)
         act_int.sa_handler = sigint_handler_hd;
     else
         act_int.sa_handler = sigint_handler;
-    sigemptyset(&act_int.sa_mask);
-    act_int.sa_flags = 0;
+    act_int.sa_flags = SA_RESTART;
     act_quit.sa_handler = SIG_IGN;
-    sigemptyset(&act_quit.sa_mask);
-    act_quit.sa_flags = 0; 
-
+    act_quit.sa_flags = 0;
     if (sigaction(SIGINT, &act_int, NULL) == -1 ||
         sigaction(SIGQUIT, &act_quit, NULL) == -1)
         pexit("sigaction()", EXIT_FAILURE, 1);


### PR DESCRIPTION
This pull request includes several changes to improve signal handling, refactor the heredoc functionality, and enhance error handling in the `minishell` project. The most important changes include adding a new mode for the signal handler, refactoring the heredoc implementation to use a child process, and improving the error handling in command path checking.

### Signal Handling Improvements:
* [`includes/macros.h`](diffhunk://#diff-14f4c851e0dac655eb97d94d8efacf18463622882bb8153e9b3bcf855e298db1R192-R194): Added a new macro `SG_HD_MODE` for the signal handler mode.
* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL253-R253): Modified the `sighandler` function to accept a `bool mode` parameter.
* [`source/utils/signals.c`](diffhunk://#diff-a3e4129845f6e137806373d4e5f37a1421134d8765ac72aab48c7039462350e3R3-L36): Added a new signal handler `sigint_handler_hd` for the heredoc mode and updated `sighandler` to handle different modes.

### Heredoc Refactoring:
* [`source/execution/redirections/hd.c`](diffhunk://#diff-b04bcb23e44faa6e0879015b6e314382083f8ade6a3716cdaaa3f5dfb0608102R17-R33): Refactored the heredoc implementation to use a child process, improving the handling of heredoc input and signals. [[1]](diffhunk://#diff-b04bcb23e44faa6e0879015b6e314382083f8ade6a3716cdaaa3f5dfb0608102R17-R33) [[2]](diffhunk://#diff-b04bcb23e44faa6e0879015b6e314382083f8ade6a3716cdaaa3f5dfb0608102L37-L65)
* [`source/execution/redirections/redirection.c`](diffhunk://#diff-39293d4b87bd25f6559e0f71bb3311ca4d00296066a5ef07e2ac99cd527e5db9L47-R47): Updated the return type of `prepare_heredoc` to match the new heredoc implementation. [[1]](diffhunk://#diff-39293d4b87bd25f6559e0f71bb3311ca4d00296066a5ef07e2ac99cd527e5db9L47-R47) [[2]](diffhunk://#diff-39293d4b87bd25f6559e0f71bb3311ca4d00296066a5ef07e2ac99cd527e5db9L56-R56)
* [`source/parser/parsing.c`](diffhunk://#diff-4c4fb30b83ae1a9a53159a340e9cfd0e5208a9e4852397e91d82276ad8969e09L35-R35): Updated the `parsing` function to handle the new return type of `prepare_heredoc`.

### Error Handling Enhancements:
* [`source/execution/utils/utils.c`](diffhunk://#diff-d5097c2e524cb1a8450a3b5fcd461641d4ec9891dd323c5f00044c82985fc36aR36-L65): Improved error handling in command path checking by using `stat` instead of `access` and providing more detailed error messages. [[1]](diffhunk://#diff-d5097c2e524cb1a8450a3b5fcd461641d4ec9891dd323c5f00044c82985fc36aR36-L65) [[2]](diffhunk://#diff-d5097c2e524cb1a8450a3b5fcd461641d4ec9891dd323c5f00044c82985fc36aL79-R83)